### PR TITLE
FIX: Iteration and mutation of primaries_down in separate threads

### DIFF
--- a/lib/rails_failover/redis/handler.rb
+++ b/lib/rails_failover/redis/handler.rb
@@ -63,7 +63,7 @@ module RailsFailover
 
         active_primaries_keys = {}
 
-        primaries_down.each do |key, options|
+        mon_synchronize { primaries_down.dup }.each do |key, options|
           info = nil
           options = options.dup
 


### PR DESCRIPTION
Ruby hashes can't be modified whilst they are being iterated over.

Here, the primaries_down hash is iterated over to check each previously
unavailable primary to see if it is now contactable. However, since this
hash can be updated in other threads, this iteration isn't safe.

To prevent this, a copy of the hash is iterated over instead.