### PR TITLE
FIX: Force redis disconnect if lock acquisition takes too long

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         ruby:
           - 2.6
           - 2.7
+        build_types: ["LINT", "REDIS", "ACTIVERECORD"]
 
     steps:
       - uses: actions/checkout@v1
@@ -27,31 +28,37 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           architecture: 'x64'
 
-      - name: Setup redis
-        run: sudo apt-get install redis-server
-
       - name: Setup bundler
         run: gem install bundler
 
       - name: Setup gems
         run: bundle install
 
-      - name: Setup test app gems
-        run: cd spec/support/dummy_app && bundle install
-
       - name: Rubocop
         run: bundle exec rubocop
+        if: env.BUILD_TYPE == 'LINT'
+
+      - name: Setup redis
+        run: sudo apt-get install redis-server
+        if: env.BUILD_TYPE == 'REDIS'
+
+      - name: Redis specs
+        run: bin/rspec redis
+        if: env.BUILD_TYPE == 'REDIS'
+
+      - name: Setup test app gems
+        run: cd spec/support/dummy_app && bundle install
+        if: env.BUILD_TYPE == 'ACTIVERECORD'
 
       - name: Setup postgres
         run: |
           make setup_pg
           make start_pg
+        if: env.BUILD_TYPE == 'ACTIVERECORD'
 
       - name: ActiveRecord specs
         run: bin/rspec active_record
-
-      - name: Redis specs
-        run: bin/rspec redis
+        if: env.BUILD_TYPE == 'ACTIVERECORD'
 
   publish:
     if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.build_types }}
 
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - 2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      BUILD_TYPE: ${{ matrix.build_types }}
+
     strategy:
       matrix:
         ruby:

--- a/lib/rails_failover/redis.rb
+++ b/lib/rails_failover/redis.rb
@@ -9,8 +9,8 @@ if Gem::Version.new(Redis::VERSION) < Gem::Version.new(supported_version)
 end
 
 require_relative "../redis/patches/client"
+require_relative "../redis/patches/connection"
 require_relative 'redis/connector'
-require_relative "../redis/patches/connector"
 
 module RailsFailover
   class Redis

--- a/lib/rails_failover/redis.rb
+++ b/lib/rails_failover/redis.rb
@@ -10,6 +10,7 @@ end
 
 require_relative "../redis/patches/client"
 require_relative 'redis/connector'
+require_relative "../redis/patches/connector"
 
 module RailsFailover
   class Redis

--- a/lib/redis/patches/connection.rb
+++ b/lib/redis/patches/connection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Redis
-  class Client
+  module Connection
     class Ruby
       def disconnect
         @sock.shutdown

--- a/lib/redis/patches/connection.rb
+++ b/lib/redis/patches/connection.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Redis
+  class Client
+    class Ruby
+      def disconnect
+        @sock.shutdown
+        @sock.close
+      rescue
+      ensure
+        @sock = nil
+      end
+    end
+  end
+end

--- a/spec/helpers/redis_helper.rb
+++ b/spec/helpers/redis_helper.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module RedisHelper
+  REDIS_PRIMARY_PORT = 6381
+  REDIS_REPLICA_PORT = 6382
   def create_redis_client(opts = {})
     Redis.new({
       host: "127.0.0.1",
-      port: 6381,
+      port: REDIS_PRIMARY_PORT,
       replica_host: "127.0.0.1",
-      replica_port: 6382,
+      replica_port: REDIS_REPLICA_PORT,
       connector: RailsFailover::Redis::Connector
     }.merge(opts))
   end

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe "Redis failover", type: :redis do
     expect(sub_redis.connection[:port]).to eq(RedisHelper::REDIS_REPLICA_PORT)
 
     system("make start_redis_primary")
-    sleep 0.2
+    sleep 2
 
     expect(simple_redis.ping).to eq("PONG")
     expect(simple_redis.connection[:port]).to eq(RedisHelper::REDIS_PRIMARY_PORT)

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -241,7 +241,11 @@ RSpec.describe "Redis failover", type: :redis do
     # Infinitely subscribe
     # This mimics things like message_bus
     subscriber = Thread.new do
-      sub_redis.subscribe("mychannel") {}
+      puts "Starting subscription"
+      sub_redis.subscribe("mychannel") {
+        puts "subscription started"
+      }
+      puts "subscription ended"
     rescue Redis::BaseConnectionError => e
       puts "error #{e.class}, retry"
       retry

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe "Redis failover", type: :redis do
     end
 
     system("make stop_redis_primary")
-    sleep 0.03
+    sleep 0.2
 
     expect(simple_redis.ping).to eq("PONG")
     expect(simple_redis.connection[:port]).to eq(RedisHelper::REDIS_REPLICA_PORT)

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -242,8 +242,11 @@ RSpec.describe "Redis failover", type: :redis do
     # This mimics things like message_bus
     subscriber = Thread.new do
       sub_redis.subscribe("mychannel") {}
-    rescue Redis::BaseConnectionError
+    rescue Redis::BaseConnectionError => e
+      puts "error #{e.class}, retry"
       retry
+    rescue => e
+      puts "error #{e.class}, exit"
     end
 
     system("make stop_redis_primary")

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -184,6 +184,91 @@ RSpec.describe "Redis failover", type: :redis do
     system("make start_redis_primary")
   end
 
+  it 'does not deadlock during disconnections' do
+    redis1 = create_redis_client
+    redis2 = create_redis_client
+
+    expect(redis1.ping).to eq("PONG")
+    expect(redis2.ping).to eq("PONG")
+
+    class <<redis1._client
+      attr_accessor :fake_longrunning_command
+      def call(commands)
+        sleep 0.1 while fake_longrunning_command
+        super
+      end
+    end
+    redis1._client.fake_longrunning_command = true
+
+    t1 = Thread.new do
+      redis1.ping
+    end
+
+    system("make stop_redis_primary")
+
+    t2 = Thread.new do
+      expect { redis2.ping }.to raise_error(Redis::CannotConnectError)
+    end
+
+    redis1._client.fake_longrunning_command = false
+
+    Timeout::timeout(5) do
+      t1.join
+      t2.join
+    end
+
+    # And now they should be failed over
+    expect(redis1.ping).to eq("PONG")
+    expect(redis2.ping).to eq("PONG")
+
+    expect(redis1.info("replication")["role"]).to eq("slave")
+    expect(redis2.info("replication")["role"]).to eq("slave")
+  rescue Timeout::Error
+    fail "Deadlock detected.\nThread 1: \n\n#{t1.backtrace.join("\n")}\n\nThread 2:\n\n#{t2.backtrace.join("\n")}\n\n"
+  ensure
+    system("make start_redis_primary")
+    t1.exit
+    t2.exit
+  end
+
+  it "handles long-running redis commands during fallback" do
+    simple_redis = create_redis_client
+    sub_redis = create_redis_client
+
+    expect(simple_redis.ping).to eq("PONG")
+    expect(sub_redis.ping).to eq("PONG")
+
+    # Infinitely subscribe
+    # This mimics things like message_bus
+    subscriber = Thread.new do
+      sub_redis.subscribe("mychannel") {}
+    rescue Redis::BaseConnectionError
+      retry
+    end
+
+    system("make stop_redis_primary")
+    sleep 0.03
+
+    expect(simple_redis.ping).to eq("PONG")
+    expect(simple_redis.connection[:port]).to eq(RedisHelper::REDIS_REPLICA_PORT)
+
+    expect(sub_redis.connected?).to eq(true)
+    expect(sub_redis.connection[:port]).to eq(RedisHelper::REDIS_REPLICA_PORT)
+
+    system("make start_redis_primary")
+    sleep 0.2
+
+    expect(simple_redis.ping).to eq("PONG")
+    expect(simple_redis.connection[:port]).to eq(RedisHelper::REDIS_PRIMARY_PORT)
+
+    expect(sub_redis.connected?).to eq(true)
+    expect(sub_redis.connection[:port]).to eq(RedisHelper::REDIS_PRIMARY_PORT)
+
+  ensure
+    system("make start_redis_primary")
+    subscriber&.exit
+  end
+
   it 'handles failover and fallback for different host/port combinations' do
     redis1 = create_redis_client
     redis2 = create_redis_client(host: "0.0.0.0", replica_host: "0.0.0.0")

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe "Redis failover", type: :redis do
     expect(simple_redis.ping).to eq("PONG")
     expect(simple_redis.connection[:port]).to eq(RedisHelper::REDIS_PRIMARY_PORT)
 
+    expect(subscriber.alive?).to eq(true)
     expect(sub_redis.connected?).to eq(true)
     expect(sub_redis.connection[:port]).to eq(RedisHelper::REDIS_PRIMARY_PORT)
 


### PR DESCRIPTION
Previously we were waiting to acquire the mutex for each connection before disconnecting it. This tries to ensure a clean disconnection, but has two issues:

- It will block forever on long-running redis commands (e.g. Pub/Sub subscriptions)
- When two clients trigger failover simultaneously, it can cause a deadlock where they each wait for the other's mutex

This commit adds a 50ms timeout, after which the client is terminated forcefully. This may cause some form of Redis::BaseConnectionError, but we expect to see some errors like this during failover anyway, so consumers should be tolerant to it.

This commit also fixes the disconnection for redis SubscribedClient instances, which were previously being skipped.