### PR TITLE
FIX: Handle concurrency issues during redis disconnection

### DIFF
--- a/lib/rails_failover/redis.rb
+++ b/lib/rails_failover/redis.rb
@@ -13,6 +13,9 @@ require_relative 'redis/connector'
 
 module RailsFailover
   class Redis
+    PRIMARY = :primary
+    REPLICA = :replica
+
     def self.logger=(logger)
       @logger = logger
     end

--- a/lib/rails_failover/redis/handler.rb
+++ b/lib/rails_failover/redis/handler.rb
@@ -215,7 +215,7 @@ module RailsFailover
             break if has_lock = redis.mon_try_enter
             break if !client.connection.connected? # Disconnected by other thread
             break if client.connection.rails_failover_role != role # Reconnected by other thread
-            time_now = Process.clock_gettime(Process::CLOCK_MONOTONIC) 
+            time_now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             break if time_now > waiting_since + SOFT_DISCONNECT_TIMEOUT_SECONDS
             sleep SOFT_DISCONNECT_POLL_SECONDS
           end

--- a/spec/helpers/redis_helper.rb
+++ b/spec/helpers/redis_helper.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module RedisHelper
+  REDIS_PRIMARY_PORT = 6381
+  REDIS_REPLICA_PORT = 6382
   def create_redis_client(opts = {})
     Redis.new({
       host: "127.0.0.1",
-      port: 6381,
+      port: REDIS_PRIMARY_PORT,
       replica_host: "127.0.0.1",
-      replica_port: 6382,
+      replica_port: REDIS_REPLICA_PORT,
       connector: RailsFailover::Redis::Connector
     }.merge(opts))
   end


### PR DESCRIPTION
This handles concurrency issues which can happen during redis failover/fallback:

- Previously, 'subscribed' redis clients were skipped during the disconnect process. This is resolved by directly accessing the original_client from the ::Redis instance

- Trying to acquire the mutex on a subscribed redis client is impossible, so the close operation would never complete. Now we send the shutdown() signal to the thread, then allow up to 1 second for the mutex to be released before we close the socket

- Failover is almost always triggered inside a redis client mutex. Failover then has its own mutex, within which we attempted to acquire mutexes for all redis clients. This logic causes a deadlock when multiple clients failover simultaneously. Now, all disconnection is performed by the Redis::Handler failover thread, outside of any other mutexes. To make this safe, the primary/replica state is stored in the connection driver, and disconnect_clients is updated to specifically target primary/replica connections.

Spec stability is also improved by ensuring the failover thread has finished running at the end of each test.