### PR TITLE
FEATURE: Run failover/fallback callbacks once for each backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2020-11-09
+- FEATURE: Run failover/fallback callbacks once for each backend
+
+  Previously the failover callback would only fire when the first backend failed, and the fallback callback would only fire when the last backend recovered. Now both failover and fallback callbacks will be triggered for each backend. The key for each backend is also passed to the callbacks for consumption by consuming applications.
+
 - FEATURE: Add primaries_down_count function to failover handlers
 
   This is intended for consumption by monitoring systems (e.g. the Discourse prometheus exporter) 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_failover (0.5.9)
+    rails_failover (0.6.0)
       activerecord (~> 6.0)
       railties (~> 6.0)
 

--- a/lib/rails_failover/active_record.rb
+++ b/lib/rails_failover/active_record.rb
@@ -47,16 +47,20 @@ module RailsFailover
       @on_failover_callback = block
     end
 
-    def self.on_failover_callback
-      @on_failover_callback
+    def self.on_failover_callback!(key)
+      @on_failover_callback&.call(key)
+    rescue => e
+      logger.warn("RailsFailover::ActiveRecord.on_failover failed: #{e.class} #{e.message}\n#{e.backtrace.join("\n")}")
     end
 
     def self.on_fallback(&block)
       @on_fallback_callback = block
     end
 
-    def self.on_fallback_callback
-      @on_fallback_callback
+    def self.on_fallback_callback!(key)
+      @on_fallback_callback&.call(key)
+    rescue => e
+      logger.warn("RailsFailover::ActiveRecord.on_fallback failed: #{e.class} #{e.message}\n#{e.backtrace.join("\n")}")
     end
   end
 end

--- a/lib/rails_failover/redis.rb
+++ b/lib/rails_failover/redis.rb
@@ -40,16 +40,20 @@ module RailsFailover
       @on_failover_callback = block
     end
 
-    def self.on_failover_callback
-      @on_failover_callback
+    def self.on_failover_callback!(key)
+      @on_failover_callback&.call(key)
+    rescue => e
+      logger.warn("RailsFailover::Redis.on_failover failed: #{e.class} #{e.message}\n#{e.backtrace.join("\n")}")
     end
 
     def self.on_fallback(&block)
       @on_fallback_callback = block
     end
 
-    def self.on_fallback_callback
-      @on_fallback_callback
+    def self.on_fallback_callback!(key)
+      @on_fallback_callback&.call(key)
+    rescue => e
+      logger.warn("RailsFailover::Redis.on_fallback failed: #{e.class} #{e.message}\n#{e.backtrace.join("\n")}")
     end
 
     # For testing

--- a/lib/rails_failover/version.rb
+++ b/lib/rails_failover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsFailover
-  VERSION = "0.5.9"
+  VERSION = "0.6.0"
 end

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -148,12 +148,12 @@ RSpec.describe "Redis failover", type: :redis do
     primary_up_called = false
     primary_down_called = false
 
-    RailsFailover::Redis.on_fallback do
-      primary_up_called = true
+    RailsFailover::Redis.on_fallback do |key|
+      primary_up_called = key
     end
 
-    RailsFailover::Redis.on_failover do
-      primary_down_called = true
+    RailsFailover::Redis.on_failover do |key|
+      primary_down_called = key
     end
 
     redis = create_redis_client
@@ -162,13 +162,13 @@ RSpec.describe "Redis failover", type: :redis do
     system("make stop_redis_primary")
 
     expect { redis.ping }.to raise_error(Redis::CannotConnectError)
-    expect(primary_down_called).to eq(true)
+    expect(primary_down_called).to eq(redis.id)
 
     system("make start_redis_primary")
 
     sleep 0.03
 
-    expect(primary_up_called).to eq(true)
+    expect(primary_up_called).to eq(redis.id)
   ensure
     RailsFailover::Redis.clear_callbacks
     system("make start_redis_primary")

--- a/spec/support/dummy_app/Gemfile.lock
+++ b/spec/support/dummy_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    rails_failover (0.5.7)
+    rails_failover (0.5.9)
       activerecord (~> 6.0)
       railties (~> 6.0)
 


### PR DESCRIPTION
Previously the failover callback would only fire when the first backend failed, and the fallback callback would only fire when the last backend recovered. Now both failover and fallback callbacks will be triggered for each backend. The key for each backend is also passed to the callbacks for consumption by consuming applications.