### PR TITLE
FEATURE: Add primaries_down_count function to failover handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- FEATURE: Add primaries_down_count function to failover handlers
+
+  This is intended for consumption by monitoring systems (e.g. the Discourse prometheus exporter) 
+
 ## [0.5.9] - 2020-11-06
 - FIX: Ignore errors from the redis socket shutdown call
 

--- a/lib/rails_failover/active_record/handler.rb
+++ b/lib/rails_failover/active_record/handler.rb
@@ -87,6 +87,10 @@ module RailsFailover
         primaries_down[handler_key]
       end
 
+      def primaries_down_count
+        primaries_down.count
+      end
+
       private
 
       def all_primaries_up

--- a/lib/rails_failover/active_record/handler.rb
+++ b/lib/rails_failover/active_record/handler.rb
@@ -88,7 +88,9 @@ module RailsFailover
       end
 
       def primaries_down_count
-        primaries_down.count
+        mon_synchronize do
+          primaries_down.count
+        end
       end
 
       private

--- a/lib/rails_failover/redis/handler.rb
+++ b/lib/rails_failover/redis/handler.rb
@@ -129,7 +129,9 @@ module RailsFailover
       end
 
       def primaries_down_count
-        primaries_down.count
+        mon_synchronize do
+          primaries_down.count
+        end
       end
 
       private

--- a/lib/rails_failover/redis/handler.rb
+++ b/lib/rails_failover/redis/handler.rb
@@ -128,6 +128,10 @@ module RailsFailover
         end
       end
 
+      def primaries_down_count
+        primaries_down.count
+      end
+
       private
 
       def all_primaries_up


### PR DESCRIPTION
This is intended for consumption by monitoring systems (e.g. the Discourse prometheus exporter)