### PR TITLE
FIX: Various potential concurrency issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2020-11-19
+
+- FIX: Use concurrent-ruby maps to simplify concurrency logic. Resolves a number of possible concurrency issues
+
 ## [0.6.1] - 2020-11-19
 
 - FIX: Recover correctly if both the primary and replica go offline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    rails_failover (0.6.1)
+    rails_failover (0.6.2)
       activerecord (~> 6.0)
+      concurrent-ruby
       railties (~> 6.0)
 
 GEM

--- a/lib/rails_failover/version.rb
+++ b/lib/rails_failover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsFailover
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/rails_failover.gemspec
+++ b/rails_failover.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   ["activerecord", "railties"].each do |gem_name|
     spec.add_dependency gem_name, "~> 6.0"
   end
+  spec.add_dependency "concurrent-ruby"
 end

--- a/spec/integration/redis_spec.rb
+++ b/spec/integration/redis_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Redis failover", type: :redis do
     ObjectSpace.each_object(Redis::Client) { |r| r.disconnect }
     system("make start_redis_primary")
     join_handler_thread
-    expect(RailsFailover::Redis::Handler.instance.send(:clients)).to eq({})
+    expect(RailsFailover::Redis::Handler.instance.send(:clients).values.all?(&:empty?)).to eq(true)
   end
 
   it 'can failover to replica and recover to primary smoothly' do


### PR DESCRIPTION
This uses concurrent-ruby maps to simplify concurrency logic. Resolves a number of possible concurrency issues

- Removes ancestor_pid instance variable, and now supports multiple forks
- Avoids calling the failover/fallback callbacks from within a mutex
- Avoids iterating over native ruby hashes
- Removes potential race conditions like `@primaries_down[process_pid] if @primaries_down[process_pid]`, where the value could change between each read

The `Concurrent::Map` api provides a number of helpers which help to reduce the amount of code requires for thread safety.

`concurrent-ruby` was already a transitive dependency, so this does not materially change the gem's dependencies.