### PR TITLE
FIX: Recover correctly if both the primary and replica go offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2020-11-19
+
+- FIX: Recover correctly if both the primary and replica go offline
+
+  Previously, a replica failing would cause it to be added to the 'primaries_down' list. The fallback handler would then continuously try and fallback the replica to itself, looping forever, and meaning that fallback to primary would never happen.
+
 ## [0.6.0] - 2020-11-09
 - FEATURE: Run failover/fallback callbacks once for each backend
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_failover (0.6.0)
+    rails_failover (0.6.1)
       activerecord (~> 6.0)
       railties (~> 6.0)
 
@@ -38,7 +38,7 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.3)
-    erubi (1.9.0)
+    erubi (1.10.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     loofah (2.7.0)

--- a/lib/rails_failover/redis/connector.rb
+++ b/lib/rails_failover/redis/connector.rb
@@ -26,7 +26,7 @@ module RailsFailover
                  Errno::ETIMEDOUT,
                  Errno::EINVAL => e
 
-            Handler.instance.verify_primary(options)
+            Handler.instance.verify_primary(options) if !is_failover_replica
             raise e
           end
 

--- a/lib/rails_failover/version.rb
+++ b/lib/rails_failover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsFailover
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
Previously, a replica failing would cause it to be added to the 'primaries_down' list. The fallback handler would then continuously try and fallback the replica to itself, looping forever, and meaning that fallback to primary would never happen.