### PR TITLE
FIX: Handle the case when the replica is set equal to the primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2020-12-09
+
+- FIX: Handle the case when the replica is set equal to the primary
+
 ## [0.6.3] - 2020-12-07
 
 - FIX: Handle clients which are connecting during fallback

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_failover (0.6.3)
+    rails_failover (0.6.4)
       activerecord (~> 6.0)
       concurrent-ruby
       railties (~> 6.0)

--- a/lib/rails_failover/version.rb
+++ b/lib/rails_failover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsFailover
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end


### PR DESCRIPTION
ed8634cc introduced a check which closed connections which do not match the expected role. In the case where the replica and primary were the same, it identified every connection as the replica, and closed it immediately. This commit flips the logic so it will identify the connection as the primary, and allow it to open successfully.