### PR TITLE
DEV: Compatibility with Rails 6.1

### DIFF
--- a/lib/rails_failover/active_record/railtie.rb
+++ b/lib/rails_failover/active_record/railtie.rb
@@ -4,7 +4,7 @@ module RailsFailover
   module ActiveRecord
     class Railtie < ::Rails::Railtie
       initializer "rails_failover.init", after: "active_record.initialize_database" do |app|
-        config = ::ActiveRecord::Base.connection_config
+        config = ::ActiveRecord::Base.connection_db_config.configuration_hash
         app.config.active_record_rails_failover = false
 
         if !!(config[:replica_host] && config[:replica_port])


### PR DESCRIPTION
`ActiveRecord::Base.connection_config` has been deprecated in Rails 6.1; the new alternative is `ActiveRecord::Base.connection_db_config.configuration_hash` which returns the same hash as the deprecated method.

This is needed for Discourse upgrade to Rails 6.1.3.1.