### PR TITLE
DEV: Add support for redis gem v4.6

### DIFF
--- a/lib/rails_failover/version.rb
+++ b/lib/rails_failover/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsFailover
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Redis 4.6 removed public access to the Monitor. We have no option other than to reach into the private instance variable via `instance_variable_get`