### PR TITLE
DEV: Move dev dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in rails_failover.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem 'rubocop-discourse'
-gem 'byebug'
-gem 'redis', '~> 4.1'
-gem 'pg', '~> 1.2'
-gem 'activerecord', '~> 6.0'
-gem 'rack'

--- a/rails_failover.gemspec
+++ b/rails_failover.gemspec
@@ -24,6 +24,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", "> 6.0", "< 7.1"
   spec.add_dependency "railties", "> 6.0", "< 7.1"
-
   spec.add_dependency "concurrent-ruby"
+
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop-discourse"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "redis", "~> 4.1"
+  spec.add_development_dependency "pg", "~> 1.2"
+  spec.add_development_dependency "activerecord", "~> 6.0"
+  spec.add_development_dependency "rack"
 end

--- a/spec/integration/active_record_spec.rb
+++ b/spec/integration/active_record_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe "ActiveRecord failover", type: :active_record do
     system("make stop_dummy_rails_server")
   end
 
+  # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do
     start_dummy_rails_server
   end
 
+  # rubocop:disable RSpec/BeforeAfterAll
   after(:all) do
     stop_dummy_rails_server
   end


### PR DESCRIPTION
(and add `rubocop:disable` comments to fix the build with the latest rubocop-discourse)