### PR TITLE
DEV: Fix flaky tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,14 @@ jobs:
           RAILS_VERSION: ${{ matrix.rails }}
         run: bin/rspec active_record
 
+      - name: Dump Unicorn STDERR logs
+        if: ${{ failure() }}
+        run: cat spec/support/dummy_app/log/unicorn.stderr.log
+
+      - name: Dump Rails logs
+        if: ${{ failure() }}
+        run: cat spec/support/dummy_app/log/production.log
+
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [lint, redis, active_record]

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ include redis.mk
 
 all: redis
 
-active_record: test_active_record
+active_record: start_pg_primary create_test_database stop_pg test_active_record
 
 test_active_record:
 	@BUNDLE_GEMFILE=./spec/support/dummy_app/Gemfile bundle install --quiet

--- a/postgresql.mk
+++ b/postgresql.mk
@@ -1,9 +1,9 @@
 PG_BIN_DIR               := $(shell pg_config --bindir)
 PWD                      := $(shell pwd)
-PG_PRIMARY_DIR           := $(PWD)/tmp/primary
+PG_PRIMARY_DIR           := /tmp/primary
 PG_PRIMARY_DATA_DIR      := $(PG_PRIMARY_DIR)/data
 PG_PRIMARY_RUN_DIR       := $(PG_PRIMARY_DIR)/run
-PG_REPLICA_DIR           := $(PWD)/tmp/replica
+PG_REPLICA_DIR           := /tmp/replica
 PG_REPLICA_DATA_DIR      := $(PG_REPLICA_DIR)/data
 PG_REPLICA_RUN_DIR       := $(PG_REPLICA_DIR)/run
 PG_PRIMARY_PORT          := 5434
@@ -14,11 +14,14 @@ PG_REPLICATION_SLOT_NAME := replication
 
 setup_pg: init_primary start_pg_primary setup_primary init_replica stop_pg_primary
 
+create_test_database:
+	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres --quiet -c "DROP DATABASE IF EXISTS test;"
+	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres --quiet -c "CREATE DATABASE test;"
+
 setup_primary:
 	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres -c "CREATE USER $(PG_REPLICATION_USER) WITH REPLICATION ENCRYPTED PASSWORD '$(PG_REPLICATION_PASSWORD)';"
 	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres -c "SELECT * FROM pg_create_physical_replication_slot('$(PG_REPLICATION_SLOT_NAME)');"
 	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres -c "CREATE USER test;"
-	@$(PG_BIN_DIR)/psql -p $(PG_PRIMARY_PORT) -h $(PG_PRIMARY_RUN_DIR) -d postgres -c "CREATE DATABASE test;"
 
 start_pg: start_pg_primary start_pg_replica
 
@@ -36,16 +39,36 @@ init_replica:
 	@chmod 0700 $(PG_REPLICA_DATA_DIR)
 
 start_pg_primary:
-	@$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_PRIMARY_DATA_DIR) -o "-p $(PG_PRIMARY_PORT)" -o "-k $(PG_PRIMARY_RUN_DIR)" start
+	@if [ ! -d "$(PG_PRIMARY_DATA_DIR)" ] || ! $(PG_BIN_DIR)/pg_ctl status -D $(PG_PRIMARY_DATA_DIR) > /dev/null 2>&1; then \
+		$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_PRIMARY_DATA_DIR) -o "-p $(PG_PRIMARY_PORT)" -o "-k $(PG_PRIMARY_RUN_DIR)" start; \
+		while ! $(PG_BIN_DIR)/pg_ctl status -D $(PG_PRIMARY_DATA_DIR) > /dev/null 2>&1; do \
+			sleep 1; \
+		done; \
+	fi
 
 start_pg_replica:
-	@$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_REPLICA_DATA_DIR) -o "-p $(PG_REPLICA_PORT)" -o "-k $(PG_REPLICA_RUN_DIR)" start
+	@if [ ! -d "$(PG_REPLICA_DATA_DIR)" ] || ! $(PG_BIN_DIR)/pg_ctl status -D $(PG_REPLICA_DATA_DIR) > /dev/null 2>&1; then \
+		$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_REPLICA_DATA_DIR) -o "-p $(PG_REPLICA_PORT)" -o "-k $(PG_REPLICA_RUN_DIR)" start; \
+		while ! $(PG_BIN_DIR)/pg_ctl status -D $(PG_REPLICA_DATA_DIR) > /dev/null 2>&1; do \
+			sleep 1; \
+		done; \
+	fi
 
 stop_pg_primary:
-	@$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_PRIMARY_DATA_DIR) -o "-p $(PG_PRIMARY_PORT)" -o "-k $(PG_PRIMARY_RUN_DIR)" stop
+	@if [ -d "$(PG_PRIMARY_DATA_DIR)" ] && $(PG_BIN_DIR)/pg_ctl status -D $(PG_PRIMARY_DATA_DIR) > /dev/null 2>&1; then \
+		$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_PRIMARY_DATA_DIR) -o "-p $(PG_PRIMARY_PORT)" -o "-k $(PG_PRIMARY_RUN_DIR)" stop; \
+		while $(PG_BIN_DIR)/pg_ctl status -D $(PG_PRIMARY_DATA_DIR) > /dev/null 2>&1; do \
+			sleep 1; \
+		done; \
+	fi
 
 stop_pg_replica:
-	@$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_REPLICA_DATA_DIR) -o "-p $(PG_REPLICA_PORT)" -o "-k $(PG_REPLICA_RUN_DIR)" stop
+	@if [ -d "$(PG_REPLICA_DATA_DIR)" ] && $(PG_BIN_DIR)/pg_ctl status -D $(PG_REPLICA_DATA_DIR) > /dev/null 2>&1; then \
+		$(PG_BIN_DIR)/pg_ctl --silent --log /dev/null -w -D $(PG_REPLICA_DATA_DIR) -o "-p $(PG_REPLICA_PORT)" -o "-k $(PG_REPLICA_RUN_DIR)" stop; \
+		while $(PG_BIN_DIR)/pg_ctl status -D $(PG_REPLICA_DATA_DIR) > /dev/null 2>&1; do \
+			sleep 1; \
+		done; \
+	fi
 
 cleanup_pg:
 	@rm -rf $(PG_PRIMARY_DIR) $(PG_REPLICA_DIR)

--- a/spec/helpers/generic_helper.rb
+++ b/spec/helpers/generic_helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 module GenericHelper
-  def wait_for(timeout:, &blk)
-    till = Time.now + (timeout.to_f / 1000)
-    sleep 0.001 while Time.now < till && !blk.call
+  def wait_for(timeout:, sleep_duration: 0.001, message: nil, &blk)
+    till = (Time.now + timeout).to_i
+
+    while Time.now.to_i < till && !blk.call
+      sleep sleep_duration
+      raise message || "Timeout after #{timeout} second" if Time.now.to_i >= till
+    end
   end
 end

--- a/spec/helpers/postgres_helper.rb
+++ b/spec/helpers/postgres_helper.rb
@@ -2,70 +2,18 @@
 
 module PostgresHelper
   def start_pg_primary
-    return if pg_primary_is_up?
     system("make start_pg_primary")
-    wait_for_pg_primary_to_be_up
   end
 
   def stop_pg_primary
-    return if pg_primary_is_down?
     system("make stop_pg_primary")
-    wait_for_pg_primary_to_be_down
   end
 
   def start_pg_replica
     system("make start_pg_replica")
-    wait_for_pg_replica_to_be_up
   end
 
   def stop_pg_replica
     system("make stop_pg_replica")
-    wait_for_pg_replica_to_be_down
-  end
-
-  private
-
-  def pg_primary_is_up?
-    File.exist?(pg_primary_pid_path)
-  end
-
-  def pg_primary_is_down?
-    !File.exist?(pg_primary_pid_path)
-  end
-
-  def wait_for_pg_primary_to_be_up
-    wait_for_pg_to_be_up(role: :primary)
-  end
-
-  def wait_for_pg_primary_to_be_down
-    wait_for_pg_to_be_down(role: :primary)
-  end
-
-  def wait_for_pg_replica_to_be_up
-    wait_for_pg_to_be_up(role: :replica)
-  end
-
-  def wait_for_pg_replica_to_be_down
-    wait_for_pg_to_be_down(role: :replica)
-  end
-
-  def wait_for_pg_to_be_up(role:)
-    wait_for(timeout: 5) { File.exist?(self.send("pg_#{role}_pid_path")) }
-  end
-
-  def wait_for_pg_to_be_down(role:)
-    wait_for(timeout: 5) { !File.exist?(self.send("pg_#{role}_pid_path")) }
-  end
-
-  def pg_replica_pid_path
-    "#{gem_root}/tmp/replica/data/postmaster.pid"
-  end
-
-  def pg_primary_pid_path
-    "#{gem_root}/tmp/primary/data/postmaster.pid"
-  end
-
-  def gem_root
-    File.expand_path("../..", __dir__)
   end
 end

--- a/spec/support/dummy_app/config/initializers/trigger_pg_exception_middleware.rb
+++ b/spec/support/dummy_app/config/initializers/trigger_pg_exception_middleware.rb
@@ -6,7 +6,7 @@ class TriggerPGException
   def call(env)
     if env["REQUEST_PATH"] == "/trigger-middleware-pg-exception"
       RailsFailover::ActiveRecord.on_failover do |role|
-        FileUtils.touch("#{Rails.root}/triggered_from_pg_exception.#{role}")
+        FileUtils.touch("/tmp/triggered_from_pg_exception.#{role}")
       end
       raise ::PG::UnableToSend
     else


### PR DESCRIPTION
`GenericHelper#wait_for` implementation was incorrect as the timeout
parameter is in seconds but the code processes it in millieseconds.

Also make creating and dropping the test database more reliable by managing it in PG directly. 
Also improve the various start/stop PG primary and replica servers command to check for PG's status.